### PR TITLE
Add new line after seeds.rb when appending

### DIFF
--- a/lib/generators/bcms_event/install/install_generator.rb
+++ b/lib/generators/bcms_event/install/install_generator.rb
@@ -9,7 +9,7 @@ class BcmsEvent::InstallGenerator < Cms::ModuleInstallation
 
   def add_seed_data_to_project
     copy_file "../bcms_event.seeds.rb", "db/bcms_event.seeds.rb"
-    append_to_file "db/seeds.rb", "load File.expand_path('../bcms_event.seeds.rb', __FILE__)"
+    append_to_file "db/seeds.rb", "load File.expand_path('../bcms_event.seeds.rb', __FILE__)\n"
   end
   
   def add_routes


### PR DESCRIPTION
I ran to a problem while adding bcms_news after bcms_event to my BrowserCMS-project. The seeds.rb appendings go to same line and that gives an error while trying to run rake db:install. There is no issue if you don't add any other modules that append this file after bcms_event. 

Unlike other modules, bcms_event didn't seem to add new line (\n) after 

``` ruby
load File.expand_path('../bcms_news.seeds.rb', __FILE__)
```

so I added it there. Other modules I am referring to are 
bcms_news (https://github.com/browsermedia/bcms_news/blob/master/lib/generators/bcms_news/install/install_generator.rb) 
and bcms_feeds (https://github.com/browsermedia/bcms_feeds/blob/master/lib/generators/bcms_bmedia_feeds/install/install_generator.rb). 

This is my first pull request ever, so if there is something I could have done different or better, please let me know.
